### PR TITLE
ENG-1245: Link directly to `Polybase DB` Whitepaper PDF

### DIFF
--- a/pages/_meta.json
+++ b/pages/_meta.json
@@ -12,7 +12,7 @@
   "whitepaper": {
     "title": "Whitepaper",
     "type": "page",
-    "href": "https://polybase.xyz/whitepaper",
+    "href": "https://framerusercontent.com/assets/GRv4t0d6jQOJbIO7ZOFgonnXqM.pdf",
     "newWindow": true
   },
   "contact": {


### PR DESCRIPTION
Changes:
  - replace link to Whitepaper landing page with direct link to the `Polybase DB` Whitepaper PDF.